### PR TITLE
Gestion de la condition inverse dans le calcule de hauteur

### DIFF
--- a/core/class/Volets.class.php
+++ b/core/class/Volets.class.php
@@ -417,7 +417,7 @@ class Volets extends eqLogic {
 			$Hauteur=0;
 		if ($Gestion == 'Azimut' && $Saison != 'hiver')
 			$Hauteur=$this->checkAltitude();
-		if($this->getConfiguration('InverseHauteur') || $this->_inverseCondition)
+		if($this->getConfiguration('InverseHauteur'))
 			$Hauteur=100-$Hauteur;
 		$this->_inverseCondition=false;
 		return $Hauteur;

--- a/core/class/Volets.class.php
+++ b/core/class/Volets.class.php
@@ -415,7 +415,7 @@ class Volets extends eqLogic {
 			$Hauteur=100;
 		elseif($Evenement == 'close')
 			$Hauteur=0;
-		if ($Gestion == 'Azimut' && $Saison != 'hiver')
+		if ($Gestion == 'Azimut' && $Saison != 'hiver' && !$this->_inverseCondition)
 			$Hauteur=$this->checkAltitude();
 		if($this->getConfiguration('InverseHauteur'))
 			$Hauteur=100-$Hauteur;

--- a/core/class/Volets.class.php
+++ b/core/class/Volets.class.php
@@ -417,8 +417,9 @@ class Volets extends eqLogic {
 			$Hauteur=0;
 		if ($Gestion == 'Azimut' && $Saison != 'hiver')
 			$Hauteur=$this->checkAltitude();
-		if($this->getConfiguration('InverseHauteur'))
+		if($this->getConfiguration('InverseHauteur') || $this->_inverseCondition)
 			$Hauteur=100-$Hauteur;
+		$this->_inverseCondition=false;
 		return $Hauteur;
 	}
 	public function AleatoireActions($Gestion,$ActionMove,$Hauteur){

--- a/docs/de_DE/index.md
+++ b/docs/de_DE/index.md
@@ -181,8 +181,10 @@ Par exemple, je veux que les volets ne se ferment que si j'ai une température a
 J'ajouterai donc une condition de ce type.
 
 ![introduction01](../images/ConditionTemps.jpg)
+
 Conditions d'exécution
 ---
+
 Afin d'affiner tous les cas d'utilisation de gestion de nos volets, nous pouvons ajouter des conditions.
 
 ![introduction01](../images/Volets_screenshot_ConfigurationCondition.jpg)
@@ -214,7 +216,7 @@ Choisissez les actions à mener sans oublier de configurer leurs valeurs.
 
 Paramètres complémentaires:
 
-* `Activer si l'action execute un mouvement du voletn` : Permet de determiné quel action execute une commande de volet
+* `Activer si l'action execute un mouvement du volet` : Permet de determiner quel action execute une commande de volet
 * `Type de gestion` : sélectionner toutes les gestions où l'action doit être exécutée (avec la touche `Ctrl`)
 * `Mode` : sélectionner tous les modes où l'action doit être exécutée (avec la touche `Ctrl`)
 * `Action` : Sélectionner toutes les actions où l'action doit être exécutée (avec la touche `Ctrl`)

--- a/docs/en_US/index.md
+++ b/docs/en_US/index.md
@@ -181,8 +181,10 @@ Par exemple, je veux que les volets ne se ferment que si j'ai une température a
 J'ajouterai donc une condition de ce type.
 
 ![introduction01](../images/ConditionTemps.jpg)
+
 Conditions d'exécution
 ---
+
 Afin d'affiner tous les cas d'utilisation de gestion de nos volets, nous pouvons ajouter des conditions.
 
 ![introduction01](../images/Volets_screenshot_ConfigurationCondition.jpg)
@@ -214,7 +216,7 @@ Choisissez les actions à mener sans oublier de configurer leurs valeurs.
 
 Paramètres complémentaires:
 
-* `Activer si l'action execute un mouvement du voletn` : Permet de determiné quel action execute une commande de volet
+* `Activer si l'action execute un mouvement du volet` : Permet de determiner quel action execute une commande de volet
 * `Type de gestion` : sélectionner toutes les gestions où l'action doit être exécutée (avec la touche `Ctrl`)
 * `Mode` : sélectionner tous les modes où l'action doit être exécutée (avec la touche `Ctrl`)
 * `Action` : Sélectionner toutes les actions où l'action doit être exécutée (avec la touche `Ctrl`)

--- a/docs/es_ES/index.md
+++ b/docs/es_ES/index.md
@@ -181,8 +181,10 @@ Par exemple, je veux que les volets ne se ferment que si j'ai une température a
 J'ajouterai donc une condition de ce type.
 
 ![introduction01](../images/ConditionTemps.jpg)
+
 Conditions d'exécution
 ---
+
 Afin d'affiner tous les cas d'utilisation de gestion de nos volets, nous pouvons ajouter des conditions.
 
 ![introduction01](../images/Volets_screenshot_ConfigurationCondition.jpg)
@@ -214,7 +216,7 @@ Choisissez les actions à mener sans oublier de configurer leurs valeurs.
 
 Paramètres complémentaires:
 
-* `Activer si l'action execute un mouvement du voletn` : Permet de determiné quel action execute une commande de volet
+* `Activer si l'action execute un mouvement du volet` : Permet de determiner quel action execute une commande de volet
 * `Type de gestion` : sélectionner toutes les gestions où l'action doit être exécutée (avec la touche `Ctrl`)
 * `Mode` : sélectionner tous les modes où l'action doit être exécutée (avec la touche `Ctrl`)
 * `Action` : Sélectionner toutes les actions où l'action doit être exécutée (avec la touche `Ctrl`)


### PR DESCRIPTION
En cas de condition inverse, on ne calcule plus la hauteur en Azimuth on impose 0 ou 100
et on remet le flag _inverseCondition a false