### PR TITLE
Typos

### DIFF
--- a/core/class/Volets.class.php
+++ b/core/class/Volets.class.php
@@ -95,7 +95,7 @@ class Volets extends eqLogic {
 						}else{
 							foreach($Volet->getConfiguration('EvenementObject') as $ObjectEvent){
 								if ($Event->getId() == str_replace('#','',$ObjectEvent['Cmd'])){
-									log::add('Volets','info',$Volet->getHumanName().$ObjectEvent['Cmd'].' : Un evenement c\'est produit sur un objet ecouté');
+									log::add('Volets','info',$Volet->getHumanName().$ObjectEvent['Cmd'].' : Un evenement s\'est produit sur un objet ecouté');
 									if (!$Volet->EvaluateCondition($_option['value'].$ObjectEvent['Operande'].$ObjectEvent['Value'],'Evenement'))
 										$Volet->GestionEvenement('open');
 									else
@@ -205,7 +205,7 @@ class Volets extends eqLogic {
 							if(is_object($Commande)){
 								$Evenement=$this->checkCondition('close',$Saison,'Evenement');   		
 								if($Evenement != false && $Evenement == 'close'){
-									log::add('Volets', 'info', $this->getHumanName().'[Gestion '.$Gestion.'] : Une condition Evenementiel est valide, nous executons la gestion Evenement');
+									log::add('Volets', 'info', $this->getHumanName().'[Gestion '.$Gestion.'] : Une condition évenementielle est valide, nous exécutons la gestion Evenement');
 									$this->CheckRepetivite('Evenement',$Evenement,$Saison,$force);
 									return false;
 								}
@@ -251,12 +251,12 @@ class Volets extends eqLogic {
 				if($force || $Evenement != false){
 					$this->checkAndUpdateCmd('isArmed',false);
 					$this->checkAndUpdateCmd('gestion','Manuel');
-					log::add('Volets','info',$this->getHumanName().'[Gestion Manuel] : Un evenement manuel a été détécté: La gestion a été désactivé');
+					log::add('Volets','info',$this->getHumanName().'[Gestion Manuel] : Un evenement manuel a été détecté: La gestion a été désactivée');
 					$this->CheckRepetivite('Manuel',$Evenement,$Saison,true);
 				}
 			}else{
 				cache::set('Volets::RearmementAutomatique::'.$this->getId(),false, 0);
-              			log::add('Volets','debug',$this->getHumanName().' Le réarmement a eu lieu on ignore l\'action manuel');
+              			log::add('Volets','debug',$this->getHumanName().' Le réarmement a eu lieu on ignore l\'action manuelle');
             		}
 		}elseif($force)	{
 			$this->checkAndUpdateCmd('gestion','Manuel');
@@ -496,7 +496,7 @@ class Volets extends eqLogic {
 		return false;
 	}
 	public function CheckActions($Gestion,$Evenement,$Saison,$Change){
-		log::add('Volets','info',$this->getHumanName().'[Gestion '.$Gestion.'] : Autorisation d\'executer les actions : '.json_encode($Change));
+		log::add('Volets','info',$this->getHumanName().'[Gestion '.$Gestion.'] : Autorisation d\'exécuter les actions : '.json_encode($Change));
 		$ActionMove=null;
 		foreach($this->getConfiguration('action') as $Cmd){	
 			if (!$this->CheckValid($Cmd,$Evenement,$Saison,$Gestion))
@@ -544,7 +544,7 @@ class Volets extends eqLogic {
 					if($key == 'slider'){
 						if($Cmd['isVoletMove']){
 							if(cache::byKey('Volets::CurrentState::'.$this->getId())->getValue(0) == $options[$key]){
-								log::add('Volets','info',$this->getHumanName().'[Gestion '.$Gestion.'] : La commande '.jeedom::toHumanReadable($Cmd['cmd']).' ne sera pas executé car la valeur est identique');
+								log::add('Volets','info',$this->getHumanName().'[Gestion '.$Gestion.'] : La commande '.jeedom::toHumanReadable($Cmd['cmd']).' ne sera pas executée car la valeur est identique');
 								return;
 							}
 							cache::set('Volets::CurrentState::'.$this->getId(),$options[$key], 0);
@@ -716,7 +716,7 @@ class Volets extends eqLogic {
 			if($ObstructionMax == '')
 				$ObstructionMax = $zenith;
 			if($Altitude < intval($ObstructionMin) || $Altitude > intval($ObstructionMax)){
-				log::add('Volets','info',$this->getHumanName().'[Gestion Altitude] : L\'altitude actuel n\'est pas dans la fenetre');
+				log::add('Volets','info',$this->getHumanName().'[Gestion Altitude] : L\'altitude actuelle n\'est pas dans la fenêtre');
 				return false;
 			}
 			return array($Altitude,$zenith); 
@@ -744,7 +744,7 @@ class Volets extends eqLogic {
 		$Hauteur=round((($Altitude-$Min)*100)/($zenith-$Min),0);
 		if($Hauteur < 0)
 			return 0;
-		log::add('Volets','info',$this->getHumanName().'[Gestion Altitude] : L\'altitude actuel est a '.$Hauteur.'% par rapport au zenith');	
+		log::add('Volets','info',$this->getHumanName().'[Gestion Altitude] : L\'altitude actuelle est à '.$Hauteur.'% par rapport au zenith');	
 		return $Hauteur;
 	}
 	public function StopDemon(){
@@ -860,15 +860,15 @@ class Volets extends eqLogic {
 	}
 	public function preSave() {
 		if($this->getConfiguration('heliotrope') == "Aucun")
-			throw new Exception(__('Impossible d\'enregister, la configuration de l\'equipement heliotrope n\'existe pas', __FILE__));
+			throw new Exception(__('Impossible d\'enregistrer, la configuration de l\'équipement heliotrope n\'existe pas', __FILE__));
 		else{
 			$heliotrope=eqlogic::byId($this->getConfiguration('heliotrope'));
 			if(is_object($heliotrope)){	
 				if($heliotrope->getConfiguration('geoloc') == "")
-					throw new Exception(__('Impossible d\'enregister, la configuration  heliotrope n\'est pas correcte', __FILE__));
+					throw new Exception(__('Impossible d\'enregistrer, la configuration  heliotrope n\'est pas correcte', __FILE__));
 				$geoloc = geotravCmd::byEqLogicIdAndLogicalId($heliotrope->getConfiguration('geoloc'),'location:coordinate');
 				if(is_object($geoloc) && $geoloc->execCmd() == '')	
-					throw new Exception(__('Impossible d\'enregister, la configuration de  "Localisation et trajet" (geotrav) n\'est pas correcte', __FILE__));
+					throw new Exception(__('Impossible d\'enregistrer, la configuration de  "Localisation et trajet" (geotrav) n\'est pas correcte', __FILE__));
 				$center=explode(",",$geoloc->execCmd());
 				$GeoLoc['lat']=$center[0];
 				$GeoLoc['lng']=$center[1];

--- a/desktop/js/Volets.js
+++ b/desktop/js/Volets.js
@@ -104,7 +104,7 @@ $('.eqLogicAttr[data-l1key=configuration][data-l2key=Azimut]').on('change',funct
 });
 $('#bt_openMap').on('click',function(){
 	$('#md_modal').dialog({
-		title: "{{Séléctionner vos angles}}",
+		title: "{{Sélectionner vos angles}}",
 		resizable: true
 	});
 	$('#md_modal').load('index.php?v=d&modal=Volets.MapsAngles&plugin=Volets&type=Volets').dialog('open');
@@ -163,7 +163,7 @@ function addEvenement(_action,  _el) {
 			.append($('<span class="input-group-btn">')
 				.append($('<a class="btn btn-default EvenementAttr" data-action="remove">')
 					.append($('<i class="fa fa-minus-circle">'))))
-			.append($('<input type="text" class="expressionAttr form-control" data-l1key="Cmd" placeholder="{{Séléctionner une commande}}"/>'))
+			.append($('<input type="text" class="expressionAttr form-control" data-l1key="Cmd" placeholder="{{Sélectionner une commande}}"/>'))
 			.append($('<span class="input-group-btn">')
 				.append($('<a class="btn btn-success btn-sm listCmdAction" data-type="info">')
 					.append($('<i class="fa fa-list-alt"></i>'))))));		
@@ -175,7 +175,7 @@ function addEvenement(_action,  _el) {
 			.append($('<option value="!=">').text('{{différent}}'))
 			.append($('<option value=" matches ">').text('{{Contient}}')) ));	
 	tr.append($('<td>')
-		.append($('<input type="text" class="expressionAttr form-control" data-l1key="Value" placeholder="{{Valeur pour validé la condition}}"/>')));
+		.append($('<input type="text" class="expressionAttr form-control" data-l1key="Value" placeholder="{{Valeur pour valider la condition}}"/>')));
 									
         _el.append(tr);
         _el.find('tr:last').setValues(_action, '.expressionAttr');

--- a/desktop/php/Volets.php
+++ b/desktop/php/Volets.php
@@ -256,7 +256,7 @@ $eqLogics = eqLogic::byType('Volets');
 				</form>
 			</div>
 			<div role="tabpanel" class="tab-pane" id="EvenementTab">
-				<p>{{La gestion Evenement va fermer le volet lorsque la condition des objets surveillé est vrai.}}</p>	
+				<p>{{La gestion Evenement va fermer le volet lorsque la condition des objets surveillés est vraie.}}</p>	
 				<p>{{Seule la gestion de Nuit est autorisée à s'exécuter}}</p>
 				<form class="form-horizontal">
 					<fieldset>
@@ -285,7 +285,7 @@ $eqLogics = eqLogic::byType('Volets');
 		<div role="tabpanel" class="tab-pane" id="ConditionnelTab">
 				<form class="form-horizontal">
 					<fieldset>
-						{{La gestion Conditionnel est une tâche executée toutes les minutes qui va verifier les conditions, par exemple météorologique, spécifées dans l'onget Condition}}	
+						{{La gestion Conditionnel est une tâche executée toutes les minutes qui va vérifier les conditions, par exemple météorologiques, spécifées dans l'onget Condition}}	
 						{{Lorsque toutes les conditions sont vérifiées le plugin passe en mode Conditionnel, les volets se ferment}}
 						{{Seule la gestion de Nuit est autorisée à s'exécuter}}		
 					</fieldset>


### PR DESCRIPTION
Hello Michael,
Faute de temps j'ai pris beaucoup de retard et sur ma Jeedom de prod c'est une très vieille version du plugin Volets qui tourne (en retard de plusieurs centaines de commits). Un de ces jours il faudra que je la mette à jour mais comme çà tournait et que je n'ai pas besoin de toutes les dernières fonctionnalités, j'ai laissé courir.
En attendant j'ai corrigé quelques typos. J'en ai sans doute oubliées.
Je n'ai pas corrigé les noms des gestions "Manuel" et "Conditionnel" en les mettant au féminin car je suppose que çà mettrait un peu la panique même si "Gestion manuel" et "Gestion conditionnel" çà pique un peu les yeux.
Je n'ai pas non plus eu le temps de parcourir la doc pour trouver les typos. Je le ferai si je trouve un peu de temps.
Merci pour tout ton travail.
Jean-Michel